### PR TITLE
feat: add link to restful e-commerce free apis for api testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Worthy sites for security testing
 - [Big List of Public APIs](https://github.com/public-apis/public-apis/blob/master/README.md)
 - [Best Buy API Playground](https://github.com/BestBuy/api-playground) - must run on your local machine.
 - [Open Movie Database API](http://www.omdbapi.com/) - API for movie data.
-
+- [Restful E-Commerce](https://github.com/mfaisalkhatri/restful-ecommerce) - A free to use E-Commerce Web APIs for practising API testing.
 
 ## Contribute
 


### PR DESCRIPTION
Added link to the Restful E-Commerce WEB APIs project. It can be used for Practising API Testing